### PR TITLE
Add initial support for multiple runners

### DIFF
--- a/bin/main.dart
+++ b/bin/main.dart
@@ -12,10 +12,17 @@ import 'package:process/process.dart';
 import 'package:tester/src/config.dart';
 import 'package:tester/tester.dart';
 
+const _allowedPlatforms = ['dart', 'web', 'flutter', 'flutter_web'];
+
 final argParser = ArgParser()
   ..addFlag('batch', abbr: 'b', help: 'Whether to run tests in batch mode.')
   ..addOption('project-root', help: 'The path to the project under test')
   ..addOption('flutter-root', help: 'The file path to the Flutter SDK.')
+  ..addOption(
+    'platform',
+    help: 'The platform to run tests on.',
+    allowed: _allowedPlatforms,
+  )
   ..addMultiOption('test');
 
 Future<void> main(List<String> args) async {
@@ -54,6 +61,8 @@ Future<void> main(List<String> args) async {
     fileSystem: const LocalFileSystem(),
     processManager: const LocalProcessManager(),
     config: Config(
+      targetPlatform: TargetPlatform
+          .values[_allowedPlatforms.indexOf(argResults['platform'] as String)],
       workspacePath: argResults['project-root'] as String,
       packageRootPath: argResults['project-root'] as String,
       testPaths: testFiles,
@@ -74,7 +83,7 @@ Future<void> main(List<String> args) async {
         'bin',
         'dart',
       ),
-      sdkRoot: fileSystem.path.join(
+      dartSdkRoot: fileSystem.path.join(
         flutterRoot,
         'bin',
         'cache',
@@ -88,6 +97,24 @@ Future<void> main(List<String> args) async {
         'lib',
         '_internal',
         'vm_platform_strong.dill',
+      ),
+      flutterPatchedSdkRoot: fileSystem.path.join(
+        flutterRoot,
+        'bin',
+        'cache',
+        'artifacts',
+        'engine',
+        'common',
+        'flutter_patched_sdk',
+      ),
+      flutterTesterPath: fileSystem.path.join(
+        flutterRoot,
+        'bin',
+        'cache',
+        'artifacts',
+        'engine',
+        cacheName,
+        'flutter_tester',
       ),
     ),
   );

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -12,8 +12,11 @@ class Config {
     @required this.workspacePath,
     @required this.packageRootPath,
     @required this.testPaths,
-    @required this.sdkRoot,
+    @required this.dartSdkRoot,
     @required this.platformDillPath,
+    @required this.flutterPatchedSdkRoot,
+    @required this.targetPlatform,
+    @required this.flutterTesterPath,
   });
 
   /// The file path to the dart executable.
@@ -32,12 +35,36 @@ class Config {
   /// `pubspec.yaml`.
   final String packageRootPath;
 
-  /// The file path to the root of the current SDK.
-  final String sdkRoot;
+  /// The file path to the root of the current Dart SDK.
+  final String dartSdkRoot;
+
+  /// The file path to the root of the current Flutter patched SDK.
+  final String flutterPatchedSdkRoot;
 
   /// The file path to the platform dill for the current SDK.
   final String platformDillPath;
 
   /// The file paths to the tests that should be executed.
   final List<String> testPaths;
+
+  /// The currently targeted platform.
+  final TargetPlatform targetPlatform;
+
+  /// The path to the flutter test device.
+  final String flutterTesterPath;
+}
+
+/// The compiler configuration for the targeted platform.
+enum TargetPlatform {
+  /// The Dart VM.
+  dart,
+
+  /// Dart in web browsers.
+  web,
+
+  /// The Flutter engine,
+  flutter,
+
+  /// The Flutter web engine,
+  flutterWeb,
 }

--- a/lib/src/isolate.dart
+++ b/lib/src/isolate.dart
@@ -33,8 +33,8 @@ class TestIsolate {
     _vmService = await vm_service.vmServiceConnectUri(websocketUrl);
 
     var vm = await _vmService.getVM();
-    _testIsolateRef = vm.isolates
-        .firstWhere((element) => element.name == launchResult.isolateName);
+    _testIsolateRef = vm.isolates.firstWhere(
+        (element) => element.name.contains(launchResult.isolateName));
 
     await _reloadLibraries();
     await _vmService.streamListen('Extension');

--- a/test_project/test/a_test.dart
+++ b/test_project/test/a_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 void testThatOneIsOne() {
-  if (1 == 1) {
+  if (1 == 2  ) {
     throw Exception('bad222');
   }
 }


### PR DESCRIPTION
now requires `--platform=dart` to function. Flutter runner does not yet work, because expression evaluation requires initial compile to kernel (so will web mode), so, need to pull in expression evaluation code