### PR TITLE
Remove dart:mirrors, initial wiring for web and flutter web tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .dart_tool/
 *.dill
+*.dill.json
+*.dill.map
+*.dill.sources
 .idea/
 .packages
 test_project/main.dart

--- a/bin/main.dart
+++ b/bin/main.dart
@@ -119,6 +119,14 @@ Future<void> main(List<String> args) async {
         cacheName,
         'flutter_tester',
       ),
+      flutterWebPlatformDillUri: File(path.join(
+        flutterRoot,
+        'bin',
+        'cache',
+        'flutter_web_sdk',
+        'kernel',
+        'flutter_ddc_sdk.dill',
+      )).uri
     ),
   );
 }

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -1,0 +1,28 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:analyzer/dart/analysis/features.dart';
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+
+/// An abstraction layer over the analyzer API.
+class Analyzer {
+  const Analyzer();
+
+  /// Collect all top-level methods that begin with 'test'.
+  List<String> collectTestNames(String testFilePath) {
+    var result = parseFile(
+        path: testFilePath, featureSet: FeatureSet.fromEnableFlags(<String>[]));
+    var testNames = <String>[];
+    for (var member in result.unit.declarations) {
+      if (member is FunctionDeclaration) {
+        var name = member.name.toString();
+        if (name.startsWith('test')) {
+          testNames.add(name);
+        }
+      }
+    }
+    return testNames;
+  }
+}

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -17,6 +17,7 @@ class Config {
     @required this.flutterPatchedSdkRoot,
     @required this.targetPlatform,
     @required this.flutterTesterPath,
+    @required this.flutterWebPlatformDillUri,
   });
 
   /// The file path to the dart executable.
@@ -43,6 +44,9 @@ class Config {
 
   /// The file URI to the platform dill for the current SDK.
   final Uri platformDillUri;
+
+  /// The file URI to the platform dill for flutter web applications.
+  final Uri flutterWebPlatformDillUri;
 
   /// The file paths to the tests that should be executed.
   final List<Uri> tests;

--- a/lib/tester.dart
+++ b/lib/tester.dart
@@ -40,10 +40,8 @@ void runApplication({
       );
       break;
     case TargetPlatform.web:
-      throw UnsupportedError('web is not yet supported');
-      break;
     case TargetPlatform.flutterWeb:
-      throw UnsupportedError('flutterWeb is not yet supported');
+      testRunner = ChromeTestRunner();
       break;
   }
   runners.add(testRunner);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,7 +9,7 @@ packages:
     source: hosted
     version: "3.0.0"
   analyzer:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
@@ -36,6 +36,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  browser_launcher:
+    dependency: transitive
+    description:
+      name: browser_launcher
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.7"
+  built_collection:
+    dependency: transitive
+    description:
+      name: built_collection
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.3.2"
+  built_value:
+    dependency: transitive
+    description:
+      name: built_value
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "7.1.0"
   charcode:
     dependency: transitive
     description:
@@ -78,6 +99,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.16.1"
+  devtools:
+    dependency: transitive
+    description:
+      name: devtools
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.5"
+  devtools_server:
+    dependency: transitive
+    description:
+      name: devtools_server
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.5"
+  devtools_shared:
+    dependency: transitive
+    description:
+      name: devtools_shared
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.5"
+  dwds:
+    dependency: "direct main"
+    description:
+      name: dwds
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.1"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.1.0"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.10.11"
   glob:
     dependency: transitive
     description:
@@ -113,6 +176,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.4"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.16.1"
   io:
     dependency: transitive
     description:
@@ -218,6 +288,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.4"
+  quiver:
+    dependency: transitive
+    description:
+      name: quiver
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.3"
   shelf:
     dependency: transitive
     description:
@@ -232,6 +309,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  shelf_proxy:
+    dependency: transitive
+    description:
+      name: shelf_proxy
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0+7"
   shelf_static:
     dependency: transitive
     description:
@@ -267,6 +351,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.7.0"
+  sse:
+    dependency: transitive
+    description:
+      name: sse
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.5.0"
   stack_trace:
     dependency: transitive
     description:
@@ -323,6 +414,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.6"
+  usage:
+    dependency: transitive
+    description:
+      name: usage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.4.1"
   uuid:
     dependency: "direct main"
     description:
@@ -352,7 +450,7 @@ packages:
     source: hosted
     version: "1.1.0"
   webkit_inspection_protocol:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,9 @@ dependencies:
   args: 1.6.0
   pedantic: 1.9.0
   path: 1.7.0
+  analyzer: 0.39.8
+  dwds: 3.1.1
+  webkit_inspection_protocol: 0.5.4
 
 dev_dependencies:
   test: 1.14.2


### PR DESCRIPTION
This wires up most of what the tool needs to spawn chrome and dwds. This is still missing a real asset server and dwds connections, but I'm leaving that for later.

Also re-adds the stdout parsing of observatory for flutter_tester, since the vm file is not supported.