### PR TITLE
Add basic smoke test, move temporaries to .dart_tool directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ dart bin/main.dart  --project-root=/path/to/tester/test_project/ --batch
 
 ```
 
-Currently this runner can only run Dart VM tests. This requires the latest TOT flutter which includes a `bin/dart` script.
+Currently this runner can only run Dart VM and Flutter tests. This requires the latest TOT flutter which includes a `bin/dart` script.

--- a/bin/main.dart
+++ b/bin/main.dart
@@ -73,13 +73,18 @@ Future<void> main(List<String> args) async {
 
   var projectDirectory =
       argResults['project-root'] as String ?? Directory.current.path;
+  var workspace =
+      Directory(path.join(projectDirectory, '.dart_tool', 'tester'));
+  if (!workspace.existsSync()) {
+    workspace.createSync(recursive: true);
+  }
 
   runApplication(
     batchMode: argResults['batch'] as bool,
     config: Config(
         targetPlatform: TargetPlatform.values[
             _allowedPlatforms.indexOf(argResults['platform'] as String)],
-        workspacePath: projectDirectory,
+        workspacePath: workspace.path,
         packageRootPath: projectDirectory,
         tests: tests,
         frontendServerPath: path.join(

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -23,15 +23,11 @@ Future<Map<String, Object>> executeTest(String name, String libraryUri) async {
   var testFunction = testRegistry[libraryUri][name];
 
   var passed = false;
-  var timeout = false;
   dynamic error;
   dynamic stackTrace;
   try {
-    await Future(() => testFunction())
-      .timeout(const Duration(seconds: 15));
+    await Future(() => testFunction());
     passed = true;
-  } on TimeoutException {
-    timeout = true;
   } catch (err, st) {
     error = err;
     stackTrace = st;
@@ -39,7 +35,7 @@ Future<Map<String, Object>> executeTest(String name, String libraryUri) async {
     return <String, Object>{
       'test': name,
       'passed': passed,
-      'timeout': timeout,
+      'timeout': false,
       'error': error?.toString(),
       'stackTrace': stackTrace?.toString(),
     };
@@ -102,7 +98,7 @@ class Compiler {
     _mainFile.writeAsStringSync(contents.toString());
 
     var dillOutput =
-        File(path.join(config.packageRootPath, 'main.dart.dill')).absolute;
+        File(path.join(config.workspacePath, 'main.dart.dill')).absolute;
 
     _stdoutHandler = StdoutHandler();
     _projectFileInvalidator = ProjectFileInvalidator();

--- a/lib/src/test_info.dart
+++ b/lib/src/test_info.dart
@@ -67,22 +67,14 @@ class TestNameCollector extends Listener {
     if (!name.startsWith('test')) {
       return;
     }
-    // Check the previous token for a comment and include if `[test]` present.
-    // The seenMarker check is necessary to avoid including file license headers
-    // in the comments for the first test in each file.
+    // Check the previous token for a comment and include if  a doc comment `///`
+    // is present.
     var description = StringBuffer();
     var comment = beginToken.precedingComments;
-    var seenMarker = false;
     while (comment != null) {
       var content = comment.toString();
-      if (content.contains('[test]')) {
-        seenMarker = true;
-      }
       if (content.startsWith('///')) {
-        content = content.substring(3);
-      }
-      if (seenMarker) {
-        description.writeln(content.trim());
+        description.writeln(content.substring(3).trim());
       }
       comment = comment.next as CommentToken;
     }

--- a/lib/tester.dart
+++ b/lib/tester.dart
@@ -62,18 +62,26 @@ void runApplication({
     exit(1);
   }
 
+  var failed = 0;
+  var passed = 0;
   await for (var testResult in testIsolate.runAllTests(testInformation)) {
     var humanFileName = path.relative(
       testResult.testFileUri.toFilePath(),
       from: config.workspacePath,
     );
     var testInfo = testInformation[testResult.testFileUri]
-      .firstWhere((info) => info.name == testResult.testName);
+        .firstWhere((info) => info.name == testResult.testName);
     if (testResult.passed == true) {
+      passed += 1;
       print('PASS    $humanFileName/${testResult.testName}');
+      print('');
+      if (testInfo.description.isNotEmpty) {
+        print(testInfo.description);
+      }
       continue;
     }
     if (!testResult.passed && !testResult.timeout) {
+      failed += 1;
       exitCode = 1;
       print('FAIL    $humanFileName/${testResult.testName}');
       print('');
@@ -87,5 +95,6 @@ void runApplication({
     print('TIMEOUT    $humanFileName/${testResult.testName}');
     exitCode = 1;
   }
+  print('${passed}/${passed + failed} tests passed.');
   exit(exitCode);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,3 @@ dependencies:
   dwds: 3.1.1
   webkit_inspection_protocol: 0.5.4
   _fe_analyzer_shared: 3.0.0
-
-dev_dependencies:
-  test: 1.14.2

--- a/test/golden_test.dart
+++ b/test/golden_test.dart
@@ -1,0 +1,49 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+void main() async {
+  var result = await Process.run(
+      'dart', <String>['bin/main.dart', '--project-root=test_project']);
+
+  expect(
+      result.stdout,
+      (dynamic line) => line.contains(
+            'Tests that a sync function that returns an object completes normally.',
+          ),
+      'prints message from doc comment');
+
+  expect(
+      result.stdout,
+      (dynamic line) =>
+          line.contains(
+              '// Copyright 2014 The Flutter Authors. All rights reserved.\n'
+              '// Use of this source code is governed by a BSD-style license that can be\n'
+              '// found in the LICENSE file.') ==
+          false,
+      'does not include license header');
+
+  expect(
+      result.stdout,
+      (dynamic line) => line.contains('This is not included') == false,
+      'does not include code comment');
+
+  expect(
+      result.stdout,
+      (dynamic line) => line.contains(
+            '4/9 tests passed.',
+          ),
+      'all expected tests pass and fail');
+}
+
+void expect(dynamic a, dynamic Function(dynamic) predicate, String cause) {
+  if (predicate(a) == false) {
+    stderr.write('FAIL');
+    stderr.writeln(cause);
+    exit(1);
+  } else {
+    stderr.writeln('PASS');
+  }
+}

--- a/test_project/test/a_test.dart
+++ b/test_project/test/a_test.dart
@@ -2,25 +2,50 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// [test] This is a test. it will pass since there is never a thrown
-/// condition, even though it isn't really "testing" anything at all.
-void testThatOneIsOne() {
-  if (1 == 1) {
-    throw Exception('bad222');
-  }
+/// Tests that a sync function completes normally
+void testNoException() {}
+
+/// Tests that a sync function that returns an object completes normally.
+Object testReturnObject() {
+  return Object();
 }
 
-/// [test] This is a test.
-Future<void> testFoo() async {
-  await Future<void>.delayed(const Duration(milliseconds: 5));
-  if ('asdsaad'.isNotEmpty) {
-    throw Exception('');
-  }
+/// Tests that a sync exception causes a test failure.
+void testSyncException() {
+  throw Exception();
 }
 
-/// [test] This is a test.
-void testSomethingElse() {
-  if ('aasdasd' == 'adad') {
-    throw Exception();
-  }
+/// Tests that a sync error causes a test failure.
+void testSyncError() {
+  throw Error();
+}
+
+/// Tests that a sync function that throws an object causes a test failure.
+void testSyncThrownObject() {
+  throw Object();
+}
+
+/// Tests that an async function with no errors completes successfully.
+Future<void> testAsyncNoException() async {
+  await null;
+}
+
+/// Tests that an async function that returns an object completes successfully.
+Future<Object> testAsyncReturnValues() async {
+  await null;
+  return Object();
+}
+
+/// Tests that an async function that completes with an exception causes a test
+/// failure.
+Future<void> testAsyncException() async {
+  await null;
+  throw Exception();
+}
+
+/// Tests that an async function that completes with an error causes a test
+/// failure.
+Future<void> testAsyncError() async {
+  await null;
+  throw Error();
 }


### PR DESCRIPTION
- Simplifies comment parsing to include `///`. Add basic smoke test for inclusion of dart doc, exclusion of comments and license headers.
- Writes dill files to .dart_tool instead of test directory.
- Removes untested timeout functionality.