### PR TITLE
Add a self-snapshotting bash entrypoint for macOS/Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,4 @@ jobs:
         run: bin/tester --platform=dart --flutter-root=../../flutter --ci -v
         working-directory: tester/tester
         env:
-          PATH: ../../flutter/bin
+          PATH: ../../flutter/bin:$PATH

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,5 +28,7 @@ jobs:
         run: ../../flutter/bin/flutter precache --no-android --no-ios
         working-directory: tester/tester
       - name: test
-        run: ../../flutter/bin/dart lib/src/executable.dart --platform=dart --flutter-root=../../flutter --ci -v
+        run: bin/tester --platform=dart --flutter-root=../../flutter --ci -v
         working-directory: tester/tester
+        env:
+          PATH: ../../flutter/bin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,20 +15,20 @@ jobs:
           repository: flutter/flutter
           fetch-depth: 0
           path: flutter
-      - name: Add Flutter SDK to PATH
-        run: "echo ::add-path::/flutter/bin/"
       - name: Dependencies
-        run: dart pub get
+        run: ../flutter/bin/dart pub get
         working-directory: tester/tester
       - name: Analyze
         run: dart analyze .
         working-directory: tester/tester
       - name: Format
-        run: dart format --set-exit-if-changed .
+        run: ../flutter/bin/dart format --set-exit-if-changed .
         working-directory: tester/tester
       - name: precache
-        run: flutter precache --no-android --no-ios
+        run: ../flutter/bin/flutter precache --no-android --no-ios
         working-directory: tester/tester
       - name: test
-        run: bin/tester --platform=dart --flutter-root=../../flutter --ci -v
+        run: bin/tester --platform=dart --ci -v
         working-directory: tester/tester
+        env:
+          FLUTTER_ROOT: ../flutter

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,20 +15,20 @@ jobs:
           repository: flutter/flutter
           fetch-depth: 0
           path: flutter
+      - name: Add Flutter SDK to PATH
+        run: "echo ::add-path::/flutter/bin/"
       - name: Dependencies
-        run: ../../flutter/bin/dart pub get
+        run: dart pub get
         working-directory: tester/tester
       - name: Analyze
-        run: ../../flutter/bin/dart analyze .
+        run: dart analyze .
         working-directory: tester/tester
       - name: Format
-        run: ../../flutter/bin/dart format --set-exit-if-changed .
+        run: dart format --set-exit-if-changed .
         working-directory: tester/tester
       - name: precache
-        run: ../../flutter/bin/flutter precache --no-android --no-ios
+        run: flutter precache --no-android --no-ios
         working-directory: tester/tester
       - name: test
         run: bin/tester --platform=dart --flutter-root=../../flutter --ci -v
         working-directory: tester/tester
-        env:
-          PATH: ../../flutter/bin:$PATH

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         run: ../../flutter/bin/dart pub get
         working-directory: tester/tester
       - name: Analyze
-        run: dart analyze .
+        run: ../../flutter/bin/dart analyze .
         working-directory: tester/tester
       - name: Format
         run: ../../flutter/bin/dart format --set-exit-if-changed .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,19 +16,19 @@ jobs:
           fetch-depth: 0
           path: flutter
       - name: Dependencies
-        run: ../flutter/bin/dart pub get
+        run: ../../flutter/bin/dart pub get
         working-directory: tester/tester
       - name: Analyze
         run: dart analyze .
         working-directory: tester/tester
       - name: Format
-        run: ../flutter/bin/dart format --set-exit-if-changed .
+        run: ../../flutter/bin/dart format --set-exit-if-changed .
         working-directory: tester/tester
       - name: precache
-        run: ../flutter/bin/flutter precache --no-android --no-ios
+        run: ../../flutter/bin/flutter precache --no-android --no-ios
         working-directory: tester/tester
       - name: test
         run: bin/tester --platform=dart --ci -v
         working-directory: tester/tester
         env:
-          FLUTTER_ROOT: ../flutter
+          FLUTTER_ROOT: ../../flutter

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,4 @@ jobs:
         working-directory: tester/tester
         env:
           FLUTTER_ROOT: ../../flutter
+          TESTER_SNAPSHOT_OVERRIDE: kernel

--- a/tester/bin/tester
+++ b/tester/bin/tester
@@ -42,6 +42,10 @@ dart_exe="dart"
 if [[ -n $FLUTTER_ROOT ]]; then
   dart_exe="$FLUTTER_ROOT/bin/dart"
 fi
+snapshot_kind="app-jit"
+if [[ -n $TESTER_SNAPSHOT_OVERRIDE ]]; then
+  snapshot_kind="$TESTER_SNAPSHOT_OVERRIDE"
+fi
 
 function generate_snapshot() {
     mkdir -p "$TESTER_ROOT/bin/cache"
@@ -50,7 +54,7 @@ function generate_snapshot() {
     if [[ ! -f "$snapshot_path" || ! -s "$version_stamp" || ! -s "$dart_stamp" || "$(cat $version_stamp)" != "$l_current_version" || "$(cat "$dart_stamp")" != "$l_current_dart_version" ]]; then
         echo "precompiling tester snapshot..."
         "$dart_exe" pub get --no-precompile > /dev/null
-        "$dart_exe" --disable-dart-dev --snapshot="$snapshot_path" --snapshot-kind=app-jit --packages="$package_config" --no-enable-mirrors "$program_entrypoint" "test/compiler_test.dart" > /dev/null
+        "$dart_exe" --disable-dart-dev --snapshot="$snapshot_path" --snapshot-kind="$snapshot_kind" --packages="$package_config" --no-enable-mirrors "$program_entrypoint" "test/compiler_test.dart" > /dev/null
         echo "$l_current_dart_version" > "$dart_stamp"
         echo "$l_current_version" > "$version_stamp"
     fi

--- a/tester/bin/tester
+++ b/tester/bin/tester
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Copyright 2014 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -e
+
+# Needed because if it is set, cd may print the path it changed to.
+unset CDPATH
+
+function follow_links() {
+  cd -P "${1%/*}"
+  local file="$PWD/${1##*/}"
+  while [[ -h "$file" ]]; do
+    # On Mac OS, readlink -f doesn't work.
+    cd -P "${file%/*}"
+    file="$(readlink "$file")"
+    cd -P "${file%/*}"
+    file="$PWD/${file##*/}"
+  done
+  echo "$PWD/${file##*/}"
+}
+
+# Convert a filesystem path to a format usable by Dart's URI parser.
+function path_uri() {
+  # Reduce multiple leading slashes to a single slash.
+  echo "$1" | sed -E -e "s,^/+,/,"
+}
+
+PROG_NAME="$(path_uri "$(follow_links "$BASH_SOURCE")")"
+BIN_DIR="$(cd "${PROG_NAME%/*}" ; pwd -P)"
+TESTER_ROOT="$(cd "${BIN_DIR}/.." ; pwd -P)"
+cache_dir="$TESTER_ROOT/bin/cache"
+snapshot_path="$cache_dir/tester.snapshot"
+version_stamp="$cache_dir/compile.stamp"
+dart_stamp="$cache_dir/dart.stamp"
+current_version="$cache_dir/version"
+package_config="$TESTER_ROOT/.dart_tool/package_config.json"
+temp_dart_ver="$cache_dir/temp_stamp"
+program_entrypoint="package:tester/src/executable.dart"
+
+function generate_snapshot() {
+    mkdir -p "$TESTER_ROOT/bin/cache"
+    local l_current_version="$(cat "$current_version")"
+    local l_current_dart_version="$(dart --disable-dart-dev --version 2>&1)"
+    if [[ ! -f "$snapshot_path" || ! -s "$version_stamp" || ! -s "$dart_stamp" || "$(cat $version_stamp)" != "$l_current_version" || "$(cat "$dart_stamp")" != "$l_current_dart_version" ]]; then
+        echo "precompiling tester snapshot..."
+        dart pub get --no-precompile > /dev/null
+        dart --disable-dart-dev --snapshot="$snapshot_path" --snapshot-kind=app-jit --packages="$package_config" --no-enable-mirrors "$program_entrypoint" "test/compiler_test.dart" > /dev/null
+        echo "$l_current_dart_version" > "$dart_stamp"
+        echo "$l_current_version" > "$version_stamp"
+    fi
+}
+
+(generate_snapshot)
+
+dart --packages="$package_config" "$snapshot_path" "$@"

--- a/tester/bin/tester
+++ b/tester/bin/tester
@@ -38,6 +38,10 @@ current_version="$cache_dir/version"
 package_config="$TESTER_ROOT/.dart_tool/package_config.json"
 temp_dart_ver="$cache_dir/temp_stamp"
 program_entrypoint="package:tester/src/executable.dart"
+dart_exe="dart"
+if [[ -n $FLUTTER_ROOT ]]; then
+  dart_exe="$FLUTTER_ROOT/bin/dart"
+fi
 
 function generate_snapshot() {
     mkdir -p "$TESTER_ROOT/bin/cache"
@@ -45,8 +49,8 @@ function generate_snapshot() {
     local l_current_dart_version="$(dart --disable-dart-dev --version 2>&1)"
     if [[ ! -f "$snapshot_path" || ! -s "$version_stamp" || ! -s "$dart_stamp" || "$(cat $version_stamp)" != "$l_current_version" || "$(cat "$dart_stamp")" != "$l_current_dart_version" ]]; then
         echo "precompiling tester snapshot..."
-        dart pub get --no-precompile > /dev/null
-        dart --disable-dart-dev --snapshot="$snapshot_path" --snapshot-kind=app-jit --packages="$package_config" --no-enable-mirrors "$program_entrypoint" "test/compiler_test.dart" > /dev/null
+        "$dart_exe" pub get --no-precompile > /dev/null
+        "$dart_exe" --disable-dart-dev --snapshot="$snapshot_path" --snapshot-kind=app-jit --packages="$package_config" --no-enable-mirrors "$program_entrypoint" "test/compiler_test.dart" > /dev/null
         echo "$l_current_dart_version" > "$dart_stamp"
         echo "$l_current_version" > "$version_stamp"
     fi
@@ -54,4 +58,4 @@ function generate_snapshot() {
 
 (generate_snapshot)
 
-dart --packages="$package_config" "$snapshot_path" "$@"
+"$dart_exe" --packages="$package_config" "$snapshot_path" "$@"

--- a/tester/lib/src/executable.dart
+++ b/tester/lib/src/executable.dart
@@ -28,9 +28,6 @@ final argParser = ArgParser()
     defaultsTo: 'coverage/lcov.info',
   )
   ..addFlag('verbose', abbr: 'v')
-  ..addOption('flutter-root',
-      help:
-          'the path to the root of a flutter checkout, if it is not available on PATH.')
   ..addFlag('ci', help: 'Run with simpler output optimized for running on CI.')
   ..addOption(
     'platform',
@@ -64,8 +61,8 @@ Future<void> main(List<String> args) async {
   var argResults = argParser.parse(args);
 
   String flutterRoot;
-  if (argResults['flutter-root'] != null) {
-    flutterRoot = argResults['flutter-root'] as String;
+  if (Platform.environment['FLUTTER_ROOT'] != null) {
+    flutterRoot = Platform.environment['FLUTTER_ROOT'];
   } else if (Platform.isWindows) {
     flutterRoot = File((await Process.run('where', <String>['flutter']))
             .stdout

--- a/tester/lib/src/writer.dart
+++ b/tester/lib/src/writer.dart
@@ -74,6 +74,8 @@ class CiTestWriter implements TestWriter {
     if (result.passed) {
       passed += 1;
     } else {
+      print(result.errorMessage);
+      print(result.stackTrace);
       failed += 1;
     }
     print(

--- a/tester/test/timeout_test.dart
+++ b/tester/test/timeout_test.dart
@@ -10,10 +10,6 @@ import 'package:test_shim/test_shim.dart';
 /// Spin up a tester process running a test that takes longer
 /// than the configured timeout.
 Future<void> testTimeoutConfigurationTimesout() async {
-  if (!Platform.isWindows) {
-    // TODO(jonahwilliams): add entrypoint for linux/mac
-    return;
-  }
   var processManager = LocalProcessManager();
   var tester = File('bin/tester').absolute.path;
   var result = await processManager.run(


### PR DESCRIPTION
The macOS/Linux side of https://github.com/jonahwilliams/tester/pull/38

Adds a bash entrypoint script which confirms the tester version (defined by bin/cache/version) and the dart SDK version (defined by dart --version) and stores them in stamp values under bin/cache. If these values are missing or different than the last execution, an app-jit snapshot is performed, using the testers own tests to bootstrap. Subsequent launches (for the same versions) will go directly to the snapshot.

Also enables timeout test that required this script.

Resolves https://github.com/jonahwilliams/tester/issues/14 by removing use of AOT