### PR TITLE
Add pub executable

### DIFF
--- a/tester/bin/tester.dart
+++ b/tester/bin/tester.dart
@@ -1,0 +1,9 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:tester/src/executable.dart' as executable;
+
+Future<void> main(List<String> args) {
+  return executable.main(args);
+}

--- a/tester/pubspec.yaml
+++ b/tester/pubspec.yaml
@@ -6,6 +6,9 @@ authors:
 environment:
   sdk: '>=2.8.0 <3.0.0'
 
+executables:
+  tester: tester
+
 dependencies:
   devtools_server: 0.2.5
   devtools: 0.2.5


### PR DESCRIPTION
This allows tester to be run via `dart pub global activate tester` and `dart pub global run tester`