### PR TITLE
infer package:test compatibility mode from package config

### DIFF
--- a/tester/lib/src/compiler.dart
+++ b/tester/lib/src/compiler.dart
@@ -390,10 +390,12 @@ class Compiler {
     @required this.testCompatMode,
     @required this.workspacePath,
     @required this.packagesRootPath,
+    @required this.packagesUri,
+    @required PackageConfig packageConfig,
     this.fileSystem = const LocalFileSystem(),
     this.processManager = const LocalProcessManager(),
     this.platform = const LocalPlatform(),
-  });
+  }) : _packageConfig = packageConfig;
 
   final FileSystem fileSystem;
   final ProcessManager processManager;
@@ -406,13 +408,14 @@ class Compiler {
   final bool testCompatMode;
   final String workspacePath;
   final String packagesRootPath;
+  final Uri packagesUri;
 
   List<Uri> _dependencies;
   DateTime _lastCompiledTime;
   StdoutHandler _stdoutHandler;
   Process _frontendServer;
   File _mainFile;
-  PackageConfig _packageConfig;
+  final PackageConfig _packageConfig;
 
   DateTime get lastCompiled => _lastCompiledTime;
 
@@ -424,17 +427,6 @@ class Compiler {
     if (!workspace.existsSync()) {
       workspace.createSync(recursive: true);
     }
-    var packagesUri = fileSystem
-        .file(fileSystem.path.join(packagesRootPath, '.packages'))
-        .absolute
-        .uri;
-    _packageConfig = await loadPackageConfigUri(packagesUri, loader: (Uri uri) {
-      var file = fileSystem.file(uri);
-      if (file.existsSync()) {
-        return file.readAsBytes();
-      }
-      return null;
-    });
     var package = testInformation.isNotEmpty
         ? _packageConfig.packageOf(testInformation.keys.first)
         : null;

--- a/tester/lib/src/executable.dart
+++ b/tester/lib/src/executable.dart
@@ -69,11 +69,6 @@ final argParser = ArgParser()
         'launch the devtools debugger and pause each test to allow stepping. ',
     defaultsTo: false,
   )
-  ..addFlag(
-    'test-compat-mode',
-    help: 'Runs in compatibiltiy mode to support package:test declarations.',
-    defaultsTo: false,
-  )
   ..addOption('flutter-root',
       help: 'The path to the root of a flutter checkout.');
 
@@ -166,7 +161,6 @@ Future<void> main(List<String> args) async {
     enabledExperiments: argResults['enable-experiment'] as List<String>,
     soundNullSafety: argResults['sound-null-safety'] as bool,
     debugger: argResults['debugger'] as bool,
-    testCompatMode: argResults['test-compat-mode'] as bool,
     targetPlatform: TargetPlatform
         .values[_allowedPlatforms.indexOf(argResults['platform'] as String)],
     workspacePath: workspace.path,

--- a/tester/test/compiler_test.dart
+++ b/tester/test/compiler_test.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:package_config/package_config.dart';
 import 'package:tester/src/compiler.dart';
 import 'package:tester/src/config.dart';
 import 'package:expect/expect.dart';
@@ -71,6 +72,8 @@ Future<void> testDartVmCompile() async {
     testCompatMode: false,
     packagesRootPath: '/project',
     workspacePath: '/project',
+    packageConfig: PackageConfig.empty,
+    packagesUri: Uri.file('/project/.packages'),
   );
 
   var uri = await compiler.start({});
@@ -130,6 +133,8 @@ Future<void> testFlutterCompile() async {
     testCompatMode: false,
     packagesRootPath: '/project',
     workspacePath: '/project',
+    packageConfig: PackageConfig.empty,
+    packagesUri: Uri.file('/project/.packages'),
   );
 
   var uri = await compiler.start({});
@@ -189,6 +194,8 @@ Future<void> testDartWebCompile() async {
     testCompatMode: false,
     packagesRootPath: '/project',
     workspacePath: '/project',
+    packageConfig: PackageConfig.empty,
+    packagesUri: Uri.file('/project/.packages'),
   );
 
   var uri = await compiler.start({});
@@ -250,6 +257,8 @@ Future<void> testFlutterWebCompile() async {
     testCompatMode: false,
     packagesRootPath: '/project',
     workspacePath: '/project',
+    packageConfig: PackageConfig.empty,
+    packagesUri: Uri.file('/project/.packages'),
   );
 
   var uri = await compiler.start({});
@@ -314,6 +323,8 @@ Future<void> testDartVmCompileWithExperiments() async {
     testCompatMode: false,
     packagesRootPath: '/project',
     workspacePath: '/project',
+    packageConfig: PackageConfig.empty,
+    packagesUri: Uri.file('/project/.packages'),
   );
 
   var uri = await compiler.start({});
@@ -373,6 +384,8 @@ Future<void> testDartVmCompileWithNullSafety() async {
     testCompatMode: false,
     packagesRootPath: '/project',
     workspacePath: '/project',
+    packageConfig: PackageConfig.empty,
+    packagesUri: Uri.file('/project/.packages'),
   );
 
   var uri = await compiler.start({});
@@ -432,6 +445,8 @@ Future<void> testDartVmCompileWithDisableNullSafety() async {
     testCompatMode: false,
     packagesRootPath: '/project',
     workspacePath: '/project',
+    packageConfig: PackageConfig.empty,
+    packagesUri: Uri.file('/project/.packages'),
   );
 
   var uri = await compiler.start({});


### PR DESCRIPTION
If test_api is defined in the package_config, implement package:test compatibility mode automatically.