### PR TITLE
fix version and flutter_test environment variable

### DIFF
--- a/tester/lib/src/runner.dart
+++ b/tester/lib/src/runner.dart
@@ -147,7 +147,9 @@ class FlutterTestRunner extends TestRunner {
       '--use-test-fonts',
       '--run-forever',
       entrypoint.toFilePath(),
-    ]);
+    ], environment: <String, String>{
+      'FLUTTER_TEST': 'true',
+    });
     unawaited(_process.exitCode.whenComplete(() {
       if (!_disposed) {
         onExit();

--- a/tester/pubspec.lock
+++ b/tester/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       name: dart_console
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.1"
+    version: "0.6.0"
   devtools:
     dependency: "direct main"
     description:

--- a/tester/pubspec.yaml
+++ b/tester/pubspec.yaml
@@ -1,5 +1,5 @@
 name: tester
-version: 0.0.1-dev2
+version: 0.0.1-dev3
 repository: https://github.com/jonahwilliams/tester
 description: An experimental test framework for Dart & Flutter.
 
@@ -19,7 +19,7 @@ dependencies:
   stream_transform: 1.2.0
   watcher: '0.9.7+15'
   stack_trace: 1.9.3
-  dart_console: 0.6.1
+  dart_console: 0.6.0
   vm_service: 4.1.0
   package_config: 1.9.3
   uuid: 2.1.0


### PR DESCRIPTION
This allows flutter unit tests to derive the correct binding. Also works around https://github.com/timsneath/dart_console/issues/23