### PR TITLE
Ensure dart sources can be looked up from package config, catch app init errors

### DIFF
--- a/tester/lib/src/application.dart
+++ b/tester/lib/src/application.dart
@@ -105,6 +105,7 @@ void runApplication({
           config: config,
           packagesRootPath: packagesRootPath,
           headless: headless,
+          packageConfig: packageConfig,
         );
         testIsolate = WebTestIsolate(testRunner: testRunner);
         break;
@@ -117,6 +118,7 @@ void runApplication({
           packagesRootPath: packagesRootPath,
           config: config,
           headless: headless,
+          packageConfig: packageConfig,
         );
         testIsolate = WebTestIsolate(testRunner: testRunner);
         break;
@@ -140,6 +142,7 @@ void runApplication({
   );
   HttpServer devtoolServer;
   if (debugger) {
+    print('VM Service listening at: ${testIsolates.single.vmServiceAddress}');
     devtoolServer = await devtools_server.serveDevTools(
       enableStdinCommands: false,
     );


### PR DESCRIPTION
Seems like the AppConnection exception is thrown if we don't wait a while for initialization. Otherwise catch and continue.

Wire up package config so the tool can sourcemap to package dependencies.