### PR TITLE
Fixes for web debugger usage

### DIFF
--- a/tester/lib/src/application.dart
+++ b/tester/lib/src/application.dart
@@ -164,6 +164,9 @@ void runApplication({
       false, // headless mode,
       false, // machine mode
     );
+    print('Press enter to begin test execution.');
+    await stdin.firstWhere((element) => true);
+    print('Starting...');
   }
 
   var random = math.Random(randomSeed);

--- a/tester/lib/src/compiler.dart
+++ b/tester/lib/src/compiler.dart
@@ -137,6 +137,11 @@ Future<Map<String, dynamic>> executeTest(String name, String libraryUri) async {
 }
 
 main() async {
+  ui.debugEmulateFlutterTesterEnvironment = true;
+  await ui.webOnlyInitializePlatform();
+  (ui.window as dynamic).debugOverrideDevicePixelRatio(3.0);
+  (ui.window as dynamic).webOnlyDebugPhysicalSizeOverride = const ui.Size(2400, 1800);
+
   registerExtension('ext.callTest', (String request, Map<String, String> args) async {
     var test = args['test'];
     var library = args['library'];
@@ -146,10 +151,6 @@ main() async {
     final result = await executeTest(test, library);
     return ServiceExtensionResponse.result(json.encode(result));
   });
-  ui.debugEmulateFlutterTesterEnvironment = true;
-  await ui.webOnlyInitializePlatform();
-  (ui.window as dynamic).debugOverrideDevicePixelRatio(3.0)
-  (ui.window as dynamic).webOnlyDebugPhysicalSizeOverride = const ui.Size(2400, 1800);
 }
 
 ''';

--- a/tester/lib/src/web_runner.dart
+++ b/tester/lib/src/web_runner.dart
@@ -212,7 +212,7 @@ class ChromeTestRunner extends TestRunner implements AssetReader {
 
     await for (var connection in _dwds.connectedApps) {
       connection.runMain();
-      await Future<void>.delayed(const Duration(milliseconds: 16));
+      await Future<void>.delayed(const Duration(milliseconds: 200));
       DebugConnection debugConnection;
       try {
         debugConnection = await _dwds.debugConnection(connection);
@@ -307,6 +307,11 @@ class ChromeTestRunner extends TestRunner implements AssetReader {
           return packageFile.readAsStringSync();
         }
       }
+    }
+    if (serverPath == 'tester/main.dart') {
+      return File(
+              path.join(packagesRootPath, '.dart_tool', 'tester', 'main.dart'))
+          .readAsStringSync();
     }
     return null;
   }

--- a/tester/lib/src/web_runner.dart
+++ b/tester/lib/src/web_runner.dart
@@ -212,7 +212,7 @@ class ChromeTestRunner extends TestRunner implements AssetReader {
 
     await for (var connection in _dwds.connectedApps) {
       connection.runMain();
-      await Future<void>.delayed(const Duration(milliseconds: 200));
+      // await Future<void>.delayed(const Duration(milliseconds: 200));
       DebugConnection debugConnection;
       try {
         debugConnection = await _dwds.debugConnection(connection);


### PR DESCRIPTION
Wait for test extension to be register before starting test run, and remove delayed future workaround. In debugger mode, delay test execution with trivial prompt since devtools cannot connect to app paused with debugger statement.