### PR TITLE
Fix relative path in watch mode, give exit control

### DIFF
--- a/tester/lib/src/application.dart
+++ b/tester/lib/src/application.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 // @dart=2.8
+import 'dart:convert';
 import 'dart:io';
 import 'dart:math' as math;
 
@@ -212,6 +213,15 @@ void runApplication({
     packagesRootPath: packagesRootPath,
     tests: tests,
   );
-  print('VM Service listening at ${testIsolates.single.vmServiceAddress}');
+  print('VM Service listening at ${testIsolates.single.vmServiceAddress}.'
+      ' Press q/Q to quit.');
   await resident.start();
+  stdin.echoMode = false;
+  stdin.lineMode = false;
+  stdin.transform(utf8.decoder).listen((String char) async {
+    if (char == 'q' || char == 'Q') {
+      await resident.dispose();
+      exit(0);
+    }
+  });
 }

--- a/tester/lib/src/resident.dart
+++ b/tester/lib/src/resident.dart
@@ -96,7 +96,7 @@ class Resident {
       if (event.type != ChangeType.MODIFY) {
         return;
       }
-      var testUri = File(event.path).absolute.uri;
+      var testUri = File(path.relative(event.path, from: packagesRootPath)).uri;
       if (testInformation[testUri] == null) {
         return;
       }


### PR DESCRIPTION
Allow exiting the watch process with q/Q and fix a bug where the absolute path was used to look up the test info (instead of the relative path).