### PR TITLE
Add compile-only and run-only flags

### DIFF
--- a/tester/lib/src/application.dart
+++ b/tester/lib/src/application.dart
@@ -40,6 +40,8 @@ void runApplication({
   @required int times,
   @required int randomSeed,
   @required bool headless,
+  @required bool compileOnly,
+  @required bool runOnly,
 }) async {
   if (!batchMode || debugger) {
     concurrency = 1;
@@ -74,9 +76,21 @@ void runApplication({
   );
   infoProvider.loadTestInfos();
   var testInfos = infoProvider.collectTestInfos(tests);
-  var result = await compiler.start(testInfos);
-  if (result == null) {
-    exit(1);
+  Uri result;
+  if (!runOnly) {
+    result = await compiler.start(testInfos);
+    if (result == null) {
+      exit(1);
+    }
+  } else {
+    result = fileSystem
+        .file(fileSystem.path
+            .join(workspacePath, 'main.${targetPlatform}.dart.dill'))
+        .absolute
+        .uri;
+  }
+  if (compileOnly) {
+    exit(0);
   }
 
   var testIsolates = <TestIsolate>[];

--- a/tester/lib/src/executable.dart
+++ b/tester/lib/src/executable.dart
@@ -84,7 +84,9 @@ final argParser = ArgParser()
   )
   ..addFlag('headless',
       defaultsTo: true,
-      help: 'Whether to run the tester/browser in headless mode.');
+      help: 'Whether to run the tester/browser in headless mode.')
+  ..addFlag('run-only', hide: true)
+  ..addFlag('compile-only', hide: true);
 
 Future<void> main(List<String> args) async {
   if (args.contains('-h') || args.contains('--help')) {
@@ -185,6 +187,8 @@ Future<void> main(List<String> args) async {
         ? int.tryParse(argResults['random-seed'] as String)
         : null,
     headless: argResults['headless'] as bool,
+    compileOnly: argResults['compile-only'] as bool,
+    runOnly: argResults['run-only'] as bool,
   );
 }
 

--- a/tester/lib/src/isolate.dart
+++ b/tester/lib/src/isolate.dart
@@ -274,7 +274,11 @@ class WebTestIsolate extends TestIsolate {
 
   Future<void> _waitForExtension(IsolateRef isolateRef) async {
     final Completer<void> completer = Completer<void>();
-    await vmService.streamListen(EventStreams.kExtension);
+    try {
+      await vmService.streamListen(EventStreams.kExtension);
+    } on RPCError {
+      // Do nothing, already subscribed.
+    }
     vmService.onExtensionEvent.listen((Event event) {
       if (event.json['extensionKind'] == 'Flutter.FrameworkInitialization') {
         completer.complete();


### PR DESCRIPTION
These allow subsequent runs to completely re-use the kernel by skipping the initial compilation and avoiding frontend_server initialization.