### PR TITLE
fix logging truncation and startup race condition

### DIFF
--- a/tester/lib/src/compiler.dart
+++ b/tester/lib/src/compiler.dart
@@ -26,7 +26,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:developer';
 
-String currentTest;
+String currentTest = '';
 
 Future<Map<String, dynamic>> executeTest(String name, String libraryUri) async {
   var libraryTests = testRegistry[libraryUri];

--- a/tester/lib/src/compiler.dart
+++ b/tester/lib/src/compiler.dart
@@ -26,6 +26,8 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:developer';
 
+String currentTest;
+
 Future<Map<String, dynamic>> executeTest(String name, String libraryUri) async {
   var libraryTests = testRegistry[libraryUri];
   if (libraryTests == null) {
@@ -35,6 +37,7 @@ Future<Map<String, dynamic>> executeTest(String name, String libraryUri) async {
   if (testFunction == null) {
     throw Exception();
   }
+  currentTest = '\$libraryUri:\$name';
 
   var passed = false;
   var timeout = false;
@@ -68,10 +71,10 @@ main() async {
   var zone = Zone.current.fork(
     specification: ZoneSpecification(
       print: (self, parent, zone, line) {
-        log(line);
+        postEvent('message', {'line': line, 'test': currentTest});
       },
       handleUncaughtError: (self, parent, zone, error, stackTrace) {
-        log('UNHANDLED EXCEPTION: \$error\\n\$stackTrace\\n');
+        postEvent('message', {'line': 'UNHANDLED EXCEPTION: \$error\\n\$stackTrace\\n'});
       },
     ),
   );
@@ -200,7 +203,7 @@ Future<Map<String, dynamic>> executeTest(String name, String libraryUri) async {
   }
 }
 
-main() async {
+main() {
   registerExtension('ext.callTest', (String request, Map<String, String> args) async {
     var test = args['test'];
     var library = args['library'];

--- a/tester/lib/src/executable.dart
+++ b/tester/lib/src/executable.dart
@@ -10,6 +10,7 @@ import 'package:args/args.dart';
 import 'package:tester/src/config.dart';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
+import 'dart:developer';
 
 import 'application.dart';
 

--- a/tester/lib/src/executable.dart
+++ b/tester/lib/src/executable.dart
@@ -10,7 +10,6 @@ import 'package:args/args.dart';
 import 'package:tester/src/config.dart';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
-import 'dart:developer';
 
 import 'application.dart';
 


### PR DESCRIPTION
The logging event truncates strings and I'm not quite sure if that is fixable, switch to a extension event which has all of the required data. Also poll for the ext.runTest extension instead of trusting the framework initialization event.