### PR TITLE
Add automatic concurrency (-j) level detection

### DIFF
--- a/tester/lib/src/executable.dart
+++ b/tester/lib/src/executable.dart
@@ -43,8 +43,9 @@ final argParser = ArgParser()
     abbr: 'j',
     help: 'The number of test isolates to run concurrently in batch mode. '
         'This option only takes effect in batch mode without --coverage or '
-        '--debugger. If not provided, defaults to 1',
-    defaultsTo: '1',
+        '--debugger. If not provided, tester will attempt to select a reasonable '
+        'default based on the number of available cores and size of the provided '
+        'test suite.',
   )
   ..addOption(
     'timeout',
@@ -173,7 +174,9 @@ Future<void> main(List<String> args) async {
         ? argResults['coverage-output'] as String
         : null,
     timeout: int.tryParse(argResults['timeout'] as String) ?? 15,
-    concurrency: int.tryParse(argResults['concurrency'] as String),
+    concurrency: argResults.wasParsed('concurrency')
+        ? int.tryParse(argResults['concurrency'] as String)
+        : null,
     enabledExperiments: argResults['enable-experiment'] as List<String>,
     soundNullSafety: argResults['sound-null-safety'] as bool,
     debugger: argResults['debugger'] as bool,

--- a/tester/test/auto_concurrency_test.dart
+++ b/tester/test/auto_concurrency_test.dart
@@ -1,0 +1,41 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart=2.8
+
+import 'package:expect/expect.dart';
+import 'package:tester/src/platform.dart';
+import 'package:tester/src/application.dart';
+
+/// Ensure core selection works reasonably well for certain configurations.
+void testCoreSelection() {
+  expect(selectCores(FakePlatform(numberOfProcessors: 0), <Uri>[]), 1);
+  expect(selectCores(FakePlatform(numberOfProcessors: 8), <Uri>[]), 1);
+  expect(
+      selectCores(FakePlatform(numberOfProcessors: 0), <Uri>[
+        Uri.file('foo'),
+        Uri.file('bar'),
+      ]),
+      1);
+  expect(
+      selectCores(FakePlatform(numberOfProcessors: 8), <Uri>[
+        Uri.file('foo'),
+        Uri.file('bar'),
+      ]),
+      2);
+  expect(
+      selectCores(FakePlatform(numberOfProcessors: 8), <Uri>[
+        Uri.file('foo'),
+        Uri.file('bar'),
+        Uri.file('foo'),
+        Uri.file('bar'),
+        Uri.file('foo'),
+        Uri.file('bar'),
+        Uri.file('foo'),
+        Uri.file('bar'),
+        Uri.file('foo'),
+        Uri.file('bar'),
+      ]),
+      7);
+}


### PR DESCRIPTION
So that it does not need to be specified each time. Make a trade-off between the number of test cases and the number of cores, preferring to stay in between the two numbers. This attempts to account for the fact that spawning a test runner has a non-zero cost, though a single test suite might not be the best measurement due to the package:test compatibility mode.